### PR TITLE
Introduce mailbox array

### DIFF
--- a/wake/bitboard_helpers.py
+++ b/wake/bitboard_helpers.py
@@ -219,11 +219,14 @@ def get_south_ray(bitboard: np.uint64, from_square: int) -> np.uint64:
     :return: np.uint64 bitboard of the southern squares attacked on an otherwise empty board
     """
     original_from_square = from_square
-    for i in range(0, -64, -8):
-        to_square = from_square + i
-        if not 0 <= to_square < 64:
-            continue
-        bitboard |= set_bit(bitboard, to_square)
+    current_square = from_square
+    
+    while current_square >= 0:
+        bitboard |= set_bit(bitboard, current_square)
+        if current_square < 8:  # Would go negative on next iteration
+            break
+        current_square -= 8
+    
     bitboard = clear_bit(bitboard, original_from_square)
     return bitboard
 
@@ -236,11 +239,14 @@ def get_north_ray(bitboard: np.uint64, from_square: int) -> np.uint64:
     :return: np.uint64 bitboard of the northern squares attacked on an otherwise empty board
     """
     original_from_square = from_square
-    for i in range(0, 64, 8):
-        to_square = from_square + i
-        if not 0 <= to_square < 64:
-            continue
-        bitboard |= set_bit(bitboard, to_square)
+    current_square = from_square
+    
+    while current_square < 64:
+        bitboard |= set_bit(bitboard, current_square)
+        if current_square >= 56:  # Would go >= 64 on next iteration
+            break
+        current_square += 8
+    
     bitboard = clear_bit(bitboard, original_from_square)
     return bitboard
 

--- a/wake/position.py
+++ b/wake/position.py
@@ -66,6 +66,7 @@ class Position:
             self.board = board
 
         self.piece_map = {}
+        self.mailbox = [None] * 64  # Mailbox array for O(1) piece lookup
 
         self.color_to_move = Color.WHITE
 
@@ -82,6 +83,7 @@ class Position:
         self.king_in_check = [0, 0]
 
         self.set_initial_piece_locations()
+        self.sync_mailbox_from_piece_map()  # Initialize mailbox after piece_map is set
 
         self.white_pawn_moves = make_uint64()
         self.white_pawn_attacks = make_uint64()
@@ -113,6 +115,16 @@ class Position:
         self.piece_map[Piece.bB] = {58, 61}
         self.piece_map[Piece.bQ] = {59}
         self.piece_map[Piece.bK] = {60}
+
+    def sync_mailbox_from_piece_map(self):
+        """
+        Synchronizes the mailbox array with the current piece_map state.
+        This provides O(1) piece lookup by square index.
+        """
+        self.mailbox = [None] * 64
+        for piece, squares in self.piece_map.items():
+            for square in squares:
+                self.mailbox[square] = piece
 
     def reset_state_to(self, memento: PositionState) -> None:
         for k, v in memento.__dict__.items():
@@ -201,8 +213,12 @@ class Position:
 
         if move.piece in {Piece.wP, Piece.bP}:
             self.halfmove_clock = 0
+        
+        # update both piece_map and mailbox
         self.piece_map[move.piece].remove(move.from_sq)
         self.piece_map[move.piece].add(move.to_sq)
+        self.mailbox[move.from_sq] = None
+        self.mailbox[move.to_sq] = move.piece
 
         if move.is_promotion:
             self.promote_pawn(move)
@@ -248,9 +264,12 @@ class Position:
             if not legal_piece:
                 print("Please choose a legal piece")
                 continue
+            
+            # Update both piece_map and mailbox
             self.piece_map[move.piece].remove(move.to_sq)
             new_piece = self.get_promotion_piece_type(legal_piece, move)
             self.piece_map[new_piece].add(move.to_sq)
+            self.mailbox[move.to_sq] = new_piece
             break
 
     def any_legal_moves(self, color_to_move):
@@ -428,12 +447,10 @@ class Position:
         return False
 
     def remove_opponent_piece_from_square(self, to_sq):
-        target = None
-        for k, v in self.piece_map.items():
-            if to_sq in v:
-                target = k
-                break
-        self.piece_map[target].remove(to_sq)
+        target = self.mailbox[to_sq]
+        if target is not None:
+            self.piece_map[target].remove(to_sq)
+            self.mailbox[to_sq] = None
 
     def update_attack_bitboards(self):
         self.reset_attack_bitboards()
@@ -517,8 +534,15 @@ class Position:
             Square.G8: (Square.H8, Square.F8),
             Square.C8: (Square.A8, Square.D8),
         }
-        self.piece_map[rook_color_map[move.color]].remove(square_map[move.to_sq][0])
-        self.piece_map[rook_color_map[move.color]].add(square_map[move.to_sq][1])
+        
+        rook_piece = rook_color_map[move.color]
+        from_sq, to_sq = square_map[move.to_sq]
+        
+        # Update both piece_map and mailbox
+        self.piece_map[rook_piece].remove(from_sq)
+        self.piece_map[rook_piece].add(to_sq)
+        self.mailbox[from_sq] = None
+        self.mailbox[to_sq] = rook_piece
 
     def reset_attack_bitboards(self):
         self.white_rook_attacks = make_uint64()
@@ -1245,10 +1269,17 @@ class Position:
         return move_result
 
     def get_piece_on_square(self, from_sq):
-        for k, v in self.piece_map.items():
-            for square in v:
-                if square == from_sq:
-                    return k
+        """
+        Returns the piece on the given square using O(1) mailbox lookup.
+        
+        Args:
+            from_sq: Square index (0-63)
+            
+        Returns:
+            Piece type or None if square is empty
+        """
+        if 0 <= from_sq < 64:
+            return self.mailbox[from_sq]
         return None
 
 


### PR DESCRIPTION
This PR introduces a [mailbox array](https://www.chessprogramming.org/Mailbox) into the engine to speed up piece lookups from linear to constant time. This is a simple change to the logic that will enable support for future search algorithm implementations. The "mailbox" structure - just a Python list in this implementation - is populated from the initial piece map. We pay the cost to build the map one time, and trade the cost of storing the mailbox list in memory for constant-time piece lookups thereafter.

- Introduce mailbox lookup and synchronize with piece map on update
- Bugfix OOB errors in bitboard helpers